### PR TITLE
Iteration 3 - 1000 parallel games; multi-game view, state management and statistic display

### DIFF
--- a/GameLogic/Constants/DisplayConstants.cs
+++ b/GameLogic/Constants/DisplayConstants.cs
@@ -24,7 +24,6 @@
         // Multi-game display constants
         public const string MultiGameDisplayHeader = "MULTI-GAME DISPLAY - GAMES RUNNING SIMULTANEOUSLY";
         public const string QuitInstruction = "Press 'Q' to return to the parallel simulation view";
-        public const string SectionDivider = "------------------------------------------------";
         public const string NavigationInstructions = "Navigate: 'N' for next page, 'P' for previous page, 'M' for multi-game view";
         public const string MultiGameNavigationInstructions = "Navigate: 'N' for next page, 'P' for previous page, 'Q' to return to main view";
         public const string ParallelGameHeaderFormat = "Parallel Game Simulation - Page {0} of {1}";
@@ -34,7 +33,7 @@
         public const string AllGamesResumed = "All games resumed.";
         public const string AllGamesSaved = "All games saved successfully!";
         public const string AllGamesLoaded = "All games loaded successfully!";
-        public const string TotalStatisticsFormat = "Iterations: {0} | Total Living Cells: {1}";
+        public const string TotalStatisticsFormat = "Iterations: {0} | Total Living Cells: {1} | Active Games: {2}/{3}";
 
         /// <summary>
         /// The representation of a living cell in the game field.

--- a/GameLogic/Constants/DisplayConstants.cs
+++ b/GameLogic/Constants/DisplayConstants.cs
@@ -6,18 +6,29 @@
         {
             StartNewGame = 1,
             LoadSavedGame = 2,
-            Quit = 3
+            StartParallelSimulation = 3,
+            Quit = 4
         }
 
         public const string StartNewGame = "1. Start a new game";
         public const string LoadSavedGame = "2. Load a saved game";
-        public const string Quit = "3. Quit";
+        public const string StartParallelSimulation = "3. Start 1000 parallel game test";
+        public const string Quit = "4. Quit";
         public const string ChooseOption = "Choose an option: ";
         public const string InvalidChoice = "Invalid choice. Please try again.";
         public const string WelcomeMessage = "Welcome to Conway's Game of Life!";
         public const string NoSavedGamesFound = "No saved games found.";
         public const string SavedGamesList = "Saved games:";
         public const string SavedGamesChoice = "Select a save file by number: ";
+
+        // Multi-game display constants
+        public const string MultiGameDisplayHeader = "MULTI-GAME DISPLAY - GAMES RUNNING SIMULTANEOUSLY";
+        public const string QuitInstruction = "Press 'Q' to return to the parallel simulation view";
+        public const string SectionDivider = "------------------------------------------------";
+        public const string NavigationInstructions = "Navigate: 'N' for next page, 'P' for previous page, 'M' for multi-game view, 'Q' to quit";
+        public const string MultiGameNavigationInstructions = "Navigate: 'N' for next page, 'P' for previous page, 'Q' to return to main view";
+        public const string ParallelGameHeaderFormat = "Parallel Game Simulation - Page {0} of {1}";
+        public const string GameSummaryFormat = "Game ID: {0} | Size: {1}x{1} | Iteration: {2} | Living Cells: {3}";
 
         /// <summary>
         /// The representation of a living cell in the game field.

--- a/GameLogic/Constants/DisplayConstants.cs
+++ b/GameLogic/Constants/DisplayConstants.cs
@@ -25,10 +25,16 @@
         public const string MultiGameDisplayHeader = "MULTI-GAME DISPLAY - GAMES RUNNING SIMULTANEOUSLY";
         public const string QuitInstruction = "Press 'Q' to return to the parallel simulation view";
         public const string SectionDivider = "------------------------------------------------";
-        public const string NavigationInstructions = "Navigate: 'N' for next page, 'P' for previous page, 'M' for multi-game view, 'Q' to quit";
+        public const string NavigationInstructions = "Navigate: 'N' for next page, 'P' for previous page, 'M' for multi-game view";
         public const string MultiGameNavigationInstructions = "Navigate: 'N' for next page, 'P' for previous page, 'Q' to return to main view";
         public const string ParallelGameHeaderFormat = "Parallel Game Simulation - Page {0} of {1}";
         public const string GameSummaryFormat = "Game ID: {0} | Size: {1}x{1} | Iteration: {2} | Living Cells: {3}";
+        public const string ParallelGameControls = "Controls: 'Spacebar' - Pause/Resume All, 'S' - Save All, 'L' - Load All, 'Q' - Quit";
+        public const string AllGamesPaused = "All games paused. Press 'Spacebar' to resume.";
+        public const string AllGamesResumed = "All games resumed.";
+        public const string AllGamesSaved = "All games saved successfully!";
+        public const string AllGamesLoaded = "All games loaded successfully!";
+        public const string TotalStatisticsFormat = "Iterations: {0} | Total Living Cells: {1}";
 
         /// <summary>
         /// The representation of a living cell in the game field.

--- a/GameLogic/Constants/FileConstants.cs
+++ b/GameLogic/Constants/FileConstants.cs
@@ -11,5 +11,10 @@
         /// The format for save file names.
         /// </summary>
         public const string SaveFileNameFormat = "{0}_{1:yyyyMMdd_HHmmss}.json";
+
+        /// <summary>
+        /// The format for parallel game save file names.
+        /// </summary>
+        public const string ParallelSaveFileNameFormat = "parallel_save_{0:yyyyMMdd_HHmmss}.json";
     }
 }

--- a/GameLogic/Constants/GameConstants.cs
+++ b/GameLogic/Constants/GameConstants.cs
@@ -20,6 +20,16 @@ namespace GameOfLife
         public const int GameUpdateSpeed = 1000;
 
         /// <summary>
+        /// The speed at which parallel games update, in milliseconds.
+        /// </summary>
+        public const int ParallelGameUpdateSpeed = 1500;
+
+        /// <summary>
+        /// The speed at which multi-game display updates, in milliseconds.
+        /// </summary>
+        public const int MultiGameUpdateSpeed = 800;
+
+        /// <summary>
         /// Sets the console output encoding to UTF-8 to display emojis correctly.
         /// </summary>
         public static void SetConsoleEncoding()

--- a/GameLogic/Constants/GameConstants.cs
+++ b/GameLogic/Constants/GameConstants.cs
@@ -22,12 +22,27 @@ namespace GameOfLife
         /// <summary>
         /// The speed at which parallel games update, in milliseconds.
         /// </summary>
-        public const int ParallelGameUpdateSpeed = 1500;
+        public const int ParallelGameUpdateSpeed = 1000;
 
         /// <summary>
-        /// The speed at which multi-game display updates, in milliseconds.
+        /// Default number of total parallel games to simulate.
         /// </summary>
-        public const int MultiGameUpdateSpeed = 800;
+        public const int DefaultTotalParallelGames = 1000;
+
+        /// <summary>
+        /// Default number of games to display per page in parallel simulation.
+        /// </summary>
+        public const int DefaultGamesPerPage = 10;
+
+        /// <summary>
+        /// Number of games to display per page in multi-game view.
+        /// </summary>
+        public const int MultiGamesPerPage = 5;
+
+        /// <summary>
+        /// Maximum number of games to display in the top row of multi-game view.
+        /// </summary>
+        public const int MultiGameTopRowCount = 3;
 
         /// <summary>
         /// Sets the console output encoding to UTF-8 to display emojis correctly.

--- a/GameLogic/Constants/GameConstants.cs
+++ b/GameLogic/Constants/GameConstants.cs
@@ -37,7 +37,7 @@ namespace GameOfLife
         /// <summary>
         /// Number of games to display per page in multi-game view.
         /// </summary>
-        public const int MultiGamesPerPage = 5;
+        public const int MultiGamesPerPage = 8;
 
         /// <summary>
         /// Maximum number of games to display in the top row of multi-game view.

--- a/GameLogic/Game.cs
+++ b/GameLogic/Game.cs
@@ -124,5 +124,15 @@ namespace GameOfLife
             // Return the iteration count
             return saveData.IterationCount;
         }
+
+        /// <summary>
+        /// Loads a game state from memory.
+        /// </summary>
+        /// <param name="state"></param>
+        public void LoadFromState(GameState state)
+        {
+            this.size = state.Size;
+            this.field = state.Field;
+        }
     }
 }

--- a/GameLogic/Interfaces/IGame.cs
+++ b/GameLogic/Interfaces/IGame.cs
@@ -24,5 +24,11 @@
         /// <param name="filePath">The path to the save file.</param>
         /// <returns>The iteration count from the save file.</returns>
         int LoadGame(string filePath);
+
+        /// <summary>
+        /// Loads a game state from memory.
+        /// </summary>
+        /// <param name="state"></param>
+        void LoadFromState(GameState state);
     }
 }

--- a/GameLogic/Managers/GameFileManager.cs
+++ b/GameLogic/Managers/GameFileManager.cs
@@ -60,5 +60,53 @@ namespace GameOfLife
                 throw;
             }
         }
+
+        /// <summary>
+        /// Saves all parallel games to a single file.
+        /// </summary>
+        public void SaveParallelGames(List<IEngine> games)
+        {
+            try
+            {
+                var saveData = new ParallelSaveData
+                {
+                    Games = games.Select(g => new GameState
+                    {
+                        Field = g.Field,
+                        IterationCount = g.IterationCount,
+                        Size = g.Field.GetLength(0)
+                    }).ToList()
+                };
+
+                string filePath = Path.Combine(FileConstants.SaveFolder,
+                    string.Format(FileConstants.ParallelSaveFileNameFormat, DateTime.Now));
+
+                string json = JsonConvert.SerializeObject(saveData, Formatting.Indented);
+                File.WriteAllText(filePath, json);
+
+                Console.WriteLine(DisplayConstants.AllGamesSaved);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error saving parallel games: {ex.Message}");
+            }
+        }
+
+        /// <summary>
+        /// Loads all parallel games from a save file.
+        /// </summary>
+        public ParallelSaveData LoadParallelGames(string filePath)
+        {
+            try
+            {
+                string json = File.ReadAllText(filePath);
+                return JsonConvert.DeserializeObject<ParallelSaveData>(json);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading parallel games: {ex.Message}");
+                throw;
+            }
+        }
     }
 }

--- a/GameLogic/Models/GameState.cs
+++ b/GameLogic/Models/GameState.cs
@@ -1,0 +1,9 @@
+﻿namespace GameOfLife
+{
+    public class GameState
+    {
+        public int Size { get; set; }
+        public bool[,] Field { get; set; }
+        public int IterationCount { get; set; }
+    }
+}

--- a/GameLogic/Models/ParallelSaveData.cs
+++ b/GameLogic/Models/ParallelSaveData.cs
@@ -1,0 +1,7 @@
+﻿namespace GameOfLife
+{
+    public class ParallelSaveData
+    {
+        public List<GameState> Games { get; set; }
+    }
+}

--- a/UserInterface/ConsoleRenderer.cs
+++ b/UserInterface/ConsoleRenderer.cs
@@ -1,28 +1,134 @@
+using System.Text;
+
 namespace GameOfLife
 {
+    public enum DisplayLayout
+    {
+        FullScreen,
+        TopRow,
+        BottomRow
+    }
+
     public class ConsoleRenderer
     {
+        private readonly StringBuilder buffer = new StringBuilder();
+
         /// <summary>
-        /// Renders the current state of the game field to the console.
+        /// Renders the current state of the game field to the console with buffer optimization.
         /// </summary>
         /// <param name="field">The game field to render.</param>
         /// <param name="iterationCount">The current iteration count.</param>
         /// <param name="livingCellCount">The current count of living cells.</param>
         public void Render(bool[,] field, int iterationCount, int livingCellCount)
         {
+            buffer.Clear();
             int size = field.GetLength(0);
 
             for (int i = 0; i < size; i++)
             {
                 for (int j = 0; j < size; j++)
                 {
-                    Console.Write(field[i, j] ? DisplayConstants.LivingCell : DisplayConstants.DeadCell);
+                    buffer.Append(field[i, j] ? DisplayConstants.LivingCell : DisplayConstants.DeadCell);
                 }
-                Console.WriteLine();
+                buffer.AppendLine();
             }
 
-            Console.WriteLine($"Iteration: {iterationCount}");
-            Console.WriteLine($"Living cells: {livingCellCount}");
+            buffer.AppendLine($"Iteration: {iterationCount}");
+            buffer.AppendLine($"Living cells: {livingCellCount}");
+
+            Console.Clear();
+            Console.Write(buffer.ToString());
+        }
+
+        /// <summary>
+        /// Renders a compact summary of a game instance.
+        /// </summary>
+        /// <param name="gameId">The ID of the game.</param>
+        /// <param name="iterationCount">The current iteration count.</param>
+        /// <param name="livingCellCount">The current count of living cells.</param>
+        /// <param name="size">The size of the game field.</param>
+        public void RenderGameSummary(int gameId, int iterationCount, int livingCellCount, int size)
+        {
+            buffer.Clear();
+            buffer.AppendFormat(DisplayConstants.GameSummaryFormat,
+                gameId, size, iterationCount, livingCellCount);
+            Console.Write(buffer.ToString());
+        }
+
+        /// <summary>
+        /// Renders multiple games side by side in a specified layout.
+        /// </summary>
+        /// <param name="engines">List of game engines to render.</param>
+        /// <param name="gameIds">List of actual game IDs for proper labeling.</param>
+        /// <param name="layout">The display layout to use.</param>
+        public void RenderMultipleGames(List<IEngine> engines, List<int> gameIds, DisplayLayout layout)
+        {
+            buffer.Clear();
+
+            // Determine display constraints based on layout
+            int maxHeight = layout == DisplayLayout.FullScreen ? 20 : 10;
+            int maxWidth = Console.WindowWidth / engines.Count;
+
+            // Create game field representations in memory
+            List<string[]> gameRepresentations = new List<string[]>();
+            for (int gameIndex = 0; gameIndex < engines.Count; gameIndex++)
+            {
+                var engine = engines[gameIndex];
+                var field = engine.Field;
+                int size = field.GetLength(0);
+                int actualGameId = gameIds[gameIndex];
+
+                // Scale the field to fit in console
+                int scaleFactor = Math.Max(1, Math.Max(1, size) / Math.Max(1, Math.Min(maxHeight, maxWidth)));
+                int scaledSize = size / scaleFactor;
+
+                string[] lines = new string[scaledSize + 3]; // Field + stats lines
+
+                // Render field with scaling
+                for (int i = 0; i < scaledSize; i++)
+                {
+                    StringBuilder lineBuilder = new StringBuilder();
+                    for (int j = 0; j < scaledSize; j++)
+                    {
+                        // Handle edge cases where scaling might cause index issues
+                        int fieldI = Math.Min(i * scaleFactor, size - 1);
+                        int fieldJ = Math.Min(j * scaleFactor, size - 1);
+
+                        bool cellValue = field[fieldI, fieldJ];
+                        lineBuilder.Append(cellValue ? DisplayConstants.LivingCell : DisplayConstants.DeadCell);
+                    }
+                    lines[i] = lineBuilder.ToString().PadRight(maxWidth);
+                }
+
+                // Add stats
+                lines[scaledSize] = $"Game ID: {actualGameId}".PadRight(maxWidth);
+                lines[scaledSize + 1] = $"Iteration: {engine.IterationCount}".PadRight(maxWidth);
+                lines[scaledSize + 2] = $"Living: {engine.LivingCellCount}".PadRight(maxWidth);
+
+                gameRepresentations.Add(lines);
+            }
+
+            // Calculate the maximum number of lines across all games
+            int maxLines = 0;
+            foreach (var rep in gameRepresentations)
+            {
+                maxLines = Math.Max(maxLines, rep.Length);
+            }
+
+            // Render games side-by-side
+            for (int lineIndex = 0; lineIndex < maxLines; lineIndex++)
+            {
+                for (int gameIndex = 0; gameIndex < gameRepresentations.Count; gameIndex++)
+                {
+                    var rep = gameRepresentations[gameIndex];
+                    string line = lineIndex < rep.Length ? rep[lineIndex] : new string(' ', maxWidth);
+                    buffer.Append(line);
+                    buffer.Append("  "); // Space between games
+                }
+                buffer.AppendLine();
+            }
+
+            Console.Write(buffer.ToString());
         }
     }
 }

--- a/UserInterface/Managers/GameMenuManager.cs
+++ b/UserInterface/Managers/GameMenuManager.cs
@@ -7,11 +7,13 @@ namespace GameOfLife
     {
         private readonly GameManager gameManager;
         private readonly ConsoleRenderer renderer;
+        private readonly SaveManager saver;
 
-        public GameMenuManager(GameManager gameManager, ConsoleRenderer renderer)
+        public GameMenuManager(GameManager gameManager, ConsoleRenderer renderer, SaveManager saver)
         {
             this.gameManager = gameManager;
             this.renderer = renderer;
+            this.saver = saver;
         }
 
         public void ShowMainMenu()
@@ -42,7 +44,7 @@ namespace GameOfLife
                             break;
                         case DisplayConstants.MenuOption.StartParallelSimulation:
                             Console.Clear();
-                            ParallelGameManager parallelManager = new ParallelGameManager(renderer);
+                            ParallelGameManager parallelManager = new ParallelGameManager(renderer, saver);
                             parallelManager.StartParallelSimulation();
                             break;
                         case DisplayConstants.MenuOption.Quit:
@@ -106,10 +108,22 @@ namespace GameOfLife
             if (int.TryParse(Console.ReadLine(), out int selectedIndex) && selectedIndex > 0 && selectedIndex <= saveFiles.Length)
             {
                 string filePath = saveFiles[selectedIndex - 1];
-                IGame game = new Game(1); // Temporary size to be overwritten by LoadGame
-                int iterationCount = game.LoadGame(filePath);
-                IEngine engine = new Engine(game, iterationCount);
-                gameManager.StartGame(engine, GameConstants.GameUpdateSpeed);
+
+
+                if (saver.IsParallelSave(filePath))
+                {
+                    // Load parallel games
+                    ParallelGameManager parallelManager = new ParallelGameManager(renderer, saver);
+                    parallelManager.LoadAllGames(filePath);
+                    parallelManager.StartParallelSimulation();
+                }
+                else
+                {
+                    IGame game = new Game(1); // Temporary size to be overwritten by LoadGame
+                    int iterationCount = game.LoadGame(filePath);
+                    IEngine engine = new Engine(game, iterationCount);
+                    gameManager.StartGame(engine, GameConstants.GameUpdateSpeed);
+                }
             }
             else
             {

--- a/UserInterface/Managers/GameMenuManager.cs
+++ b/UserInterface/Managers/GameMenuManager.cs
@@ -1,12 +1,17 @@
-﻿namespace GameOfLife
+﻿using System;
+using System.IO;
+
+namespace GameOfLife
 {
     public class GameMenuManager
     {
         private readonly GameManager gameManager;
+        private readonly ConsoleRenderer renderer;
 
-        public GameMenuManager(GameManager gameManager)
+        public GameMenuManager(GameManager gameManager, ConsoleRenderer renderer)
         {
             this.gameManager = gameManager;
+            this.renderer = renderer;
         }
 
         public void ShowMainMenu()
@@ -16,6 +21,7 @@
                 Console.WriteLine(DisplayConstants.WelcomeMessage);
                 Console.WriteLine(DisplayConstants.StartNewGame);
                 Console.WriteLine(DisplayConstants.LoadSavedGame);
+                Console.WriteLine(DisplayConstants.StartParallelSimulation);
                 Console.WriteLine(DisplayConstants.Quit);
                 Console.Write(DisplayConstants.ChooseOption);
 
@@ -33,6 +39,11 @@
                         case DisplayConstants.MenuOption.LoadSavedGame:
                             Console.Clear();
                             LoadSavedGame();
+                            break;
+                        case DisplayConstants.MenuOption.StartParallelSimulation:
+                            Console.Clear();
+                            ParallelGameManager parallelManager = new ParallelGameManager(renderer);
+                            parallelManager.StartParallelSimulation();
                             break;
                         case DisplayConstants.MenuOption.Quit:
                             return;

--- a/UserInterface/Managers/ParallelGameManager.cs
+++ b/UserInterface/Managers/ParallelGameManager.cs
@@ -1,0 +1,302 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace GameOfLife
+{
+    /// <summary>
+    /// Manages multiple parallel game instances for mass simulation and testing.
+    /// </summary>
+    public class ParallelGameManager
+    {
+        private readonly ConsoleRenderer renderer;
+        private readonly List<IEngine> games = new List<IEngine>();
+        private readonly CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+        private readonly object syncLock = new object();
+        private readonly int totalGames;
+        private readonly int gamesPerPage;
+        private int currentPage = 0;
+        private int multiGamePage = 0;
+        private int multiGamesPerPage = 5;
+        private bool inMultiGameView = false;
+
+        /// <summary>
+        /// Initializes a new instance of the ParallelGameManager class.
+        /// </summary>
+        /// <param name="renderer">The console renderer instance used for display.</param>
+        /// <param name="totalGames">The total number of games to simulate.</param>
+        /// <param name="gamesPerPage">The number of games to display per page.</param>
+        public ParallelGameManager(ConsoleRenderer renderer, int totalGames = 1000, int gamesPerPage = 10)
+        {
+            this.renderer = renderer;
+            this.totalGames = totalGames;
+            this.gamesPerPage = gamesPerPage;
+            InitializeGames();
+        }
+
+        /// <summary>
+        /// Initializes the specified number of game instances with random sizes.
+        /// </summary>
+        private void InitializeGames()
+        {
+            Random random = new Random();
+            for (int i = 0; i < totalGames; i++)
+            {
+                int size = random.Next(GameConstants.MinFieldSize, GameConstants.MaxFieldSize + 1);
+                IGame game = new Game(size);
+                IEngine engine = new Engine(game);
+                games.Add(engine);
+            }
+        }
+
+        /// <summary>
+        /// Starts the parallel game simulation and manages user navigation.
+        /// </summary>
+        public void StartParallelSimulation()
+        {
+            Task simulationTask = Task.Run(() => RunParallelSimulation(cancellationTokenSource.Token));
+
+            bool running = true;
+            while (running && !cancellationTokenSource.IsCancellationRequested)
+            {
+                if (Console.KeyAvailable)
+                {
+                    var key = Console.ReadKey(true).Key;
+                    switch (key)
+                    {
+                        case ConsoleKey.N:
+                            if (!inMultiGameView)
+                            {
+                                NextPage();
+                            }
+                            break;
+                        case ConsoleKey.P:
+                            if (!inMultiGameView)
+                            {
+                                PreviousPage();
+                            }
+                            break;
+                        case ConsoleKey.M:
+                            if (!inMultiGameView)
+                            {
+                                inMultiGameView = true;
+                                multiGamePage = 0; // Reset to first page when entering multi-game view
+                                ShowMultiGameDisplay();
+                                inMultiGameView = false;
+                            }
+                            break;
+                        case ConsoleKey.Q:
+                            Console.Clear();
+                            running = false;
+                            break;
+                    }
+                }
+                Thread.Sleep(100); // Prevent CPU hogging in input loop
+            }
+
+            cancellationTokenSource.Cancel();
+            try
+            {
+                simulationTask.Wait();
+            }
+            catch (AggregateException)
+            {
+                // Task was canceled, which is expected
+            }
+        }
+
+        /// <summary>
+        /// Runs the parallel simulation for all game instances.
+        /// </summary>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        private void RunParallelSimulation(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // Update all games in parallel
+                Parallel.ForEach(games, game =>
+                {
+                    game.UpdateGameState();
+                });
+
+                // Only display current page if not in multi-game view
+                if (!inMultiGameView)
+                {
+                    DisplayCurrentPage();
+                }
+
+                Thread.Sleep(GameConstants.ParallelGameUpdateSpeed);
+            }
+        }
+
+        /// <summary>
+        /// Displays the current page of game instances.
+        /// </summary>
+        private void DisplayCurrentPage()
+        {
+            lock (syncLock)
+            {
+                Console.Clear();
+                int startIndex = currentPage * gamesPerPage;
+                int endIndex = Math.Min(startIndex + gamesPerPage, totalGames);
+
+                Console.WriteLine(DisplayConstants.ParallelGameHeaderFormat, currentPage + 1, (int)Math.Ceiling((double)totalGames / gamesPerPage));
+                Console.WriteLine(DisplayConstants.NavigationInstructions);
+                Console.WriteLine();
+
+                var displayGames = games.Skip(startIndex).Take(gamesPerPage).ToList();
+
+                for (int i = 0; i < displayGames.Count; i++)
+                {
+                    int gameId = startIndex + i + 1;
+                    IEngine game = displayGames[i];
+                    renderer.RenderGameSummary(gameId, game.IterationCount, game.LivingCellCount, game.Field.GetLength(0));
+                    Console.WriteLine();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Moves to the next page of games.
+        /// </summary>
+        private void NextPage()
+        {
+            lock (syncLock)
+            {
+                int totalPages = (int)Math.Ceiling((double)totalGames / gamesPerPage);
+                currentPage = (currentPage + 1) % totalPages;
+            }
+        }
+
+        /// <summary>
+        /// Moves to the previous page of games.
+        /// </summary>
+        private void PreviousPage()
+        {
+            lock (syncLock)
+            {
+                int totalPages = (int)Math.Ceiling((double)totalGames / gamesPerPage);
+                currentPage = (currentPage - 1 + totalPages) % totalPages;
+            }
+        }
+
+        /// <summary>
+        /// Displays multiple games simultaneously in a grid layout with pagination.
+        /// </summary>
+        public void ShowMultiGameDisplay()
+        {
+            CancellationTokenSource multiDisplayCts = new CancellationTokenSource();
+            Task displayTask = Task.Run(() => RunMultiGameDisplay(multiDisplayCts.Token));
+
+            // Wait for user to press navigation keys or Q to quit
+            while (!multiDisplayCts.IsCancellationRequested)
+            {
+                if (Console.KeyAvailable)
+                {
+                    var key = Console.ReadKey(true).Key;
+                    switch (key)
+                    {
+                        case ConsoleKey.N:
+                            lock (syncLock)
+                            {
+                                int totalPages = (int)Math.Ceiling((double)totalGames / multiGamesPerPage);
+                                multiGamePage = (multiGamePage + 1) % totalPages;
+                            }
+                            break;
+                        case ConsoleKey.P:
+                            lock (syncLock)
+                            {
+                                int totalPages = (int)Math.Ceiling((double)totalGames / multiGamesPerPage);
+                                multiGamePage = (multiGamePage - 1 + totalPages) % totalPages;
+                            }
+                            break;
+                        case ConsoleKey.Q:
+                            multiDisplayCts.Cancel();
+                            break;
+                    }
+                }
+                Thread.Sleep(100);
+            }
+
+            try
+            {
+                displayTask.Wait();
+            }
+            catch (AggregateException)
+            {
+                // Task was canceled, which is expected
+            }
+        }
+
+        /// <summary>
+        /// Runs the multi-game display showing games updating simultaneously with pagination.
+        /// </summary>
+        /// <param name="cancellationToken">Token to monitor for cancellation requests.</param>
+        private void RunMultiGameDisplay(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                // Get games from the current multi-game page
+                int startIndex = multiGamePage * multiGamesPerPage;
+                List<IEngine> displayGames = new List<IEngine>();
+                List<int> gameIds = new List<int>();
+
+                // Get up to 5 games for current page
+                for (int i = 0; i < multiGamesPerPage; i++)
+                {
+                    int gameIndex = startIndex + i;
+                    if (gameIndex < totalGames)
+                    {
+                        displayGames.Add(games[gameIndex]);
+                        gameIds.Add(gameIndex + 1); // Add 1 to make game IDs 1-based
+                    }
+                }
+
+                lock (syncLock)
+                {
+                    Console.Clear();
+
+                    // Display pagination info
+                    int totalPages = (int)Math.Ceiling((double)totalGames / multiGamesPerPage);
+                    Console.WriteLine(DisplayConstants.MultiGameDisplayHeader);
+                    Console.WriteLine($"Page {multiGamePage + 1} of {totalPages}");
+                    Console.WriteLine(DisplayConstants.MultiGameNavigationInstructions);
+                    Console.WriteLine();
+
+                    // Split games for display layout
+                    int topRowCount = Math.Min(3, displayGames.Count);
+                    int bottomRowCount = displayGames.Count - topRowCount;
+
+                    // Display top row
+                    if (topRowCount > 0)
+                    {
+                        renderer.RenderMultipleGames(
+                            displayGames.Take(topRowCount).ToList(),
+                            gameIds.Take(topRowCount).ToList(),
+                            DisplayLayout.TopRow
+                        );
+                    }
+
+                    // Display section divider if we have games for both rows
+                    if (bottomRowCount > 0)
+                    {
+                        Console.WriteLine();
+                        Console.WriteLine(DisplayConstants.SectionDivider);
+                        Console.WriteLine();
+
+                        // Display bottom row
+                        renderer.RenderMultipleGames(
+                            displayGames.Skip(topRowCount).Take(bottomRowCount).ToList(),
+                            gameIds.Skip(topRowCount).Take(bottomRowCount).ToList(),
+                            DisplayLayout.BottomRow
+                        );
+                    }
+                }
+
+                Thread.Sleep(GameConstants.MultiGameUpdateSpeed);
+            }
+        }
+    }
+}

--- a/UserInterface/Managers/SaveManager.cs
+++ b/UserInterface/Managers/SaveManager.cs
@@ -1,17 +1,72 @@
-﻿namespace GameOfLife
+﻿using Newtonsoft.Json;
+
+namespace GameOfLife
 {
     public class SaveManager
     {
         private readonly GameFileManager fileManager = new GameFileManager();
 
+        /// <summary>
+        /// Saves a single game state to a JSON file.
+        /// </summary>
+        /// <param name="fileName"></param>
+        /// <param name="iterationCount"></param>
+        /// <param name="size"></param>
+        /// <param name="field"></param>
         public void SaveGame(string fileName, int iterationCount, int size, bool[,] field)
         {
             fileManager.SaveGame(fileName, iterationCount, size, field);
         }
 
+        /// <summary>
+        /// Loads a single game state from a JSON file.
+        /// </summary>
+        /// <param name="filePath"></param>
+        /// <returns></returns>
         public SaveData LoadGame(string filePath)
         {
             return fileManager.LoadGame(filePath);
+        }
+
+        /// <summary>
+        /// Detects if a save file contains parallel games.
+        /// </summary>
+        public bool IsParallelSave(string filePath)
+        {
+            try
+            {
+                string json = File.ReadAllText(filePath);
+                var saveData = JsonConvert.DeserializeObject<ParallelSaveData>(json);
+                return saveData != null && saveData.Games != null && saveData.Games.Count > 1;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Loads a parallel game save file.
+        /// </summary>
+        public ParallelSaveData LoadParallelGames(string filePath)
+        {
+            try
+            {
+                return fileManager.LoadParallelGames(filePath);
+            }
+            catch (Exception ex)
+            {
+                Console.WriteLine($"Error loading parallel games: {ex.Message}");
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Saves all parallel games.
+        /// </summary>
+        public void SaveParallelGames(List<IEngine> games)
+        {
+            fileManager.SaveParallelGames(games);
         }
     }
 }

--- a/UserInterface/Program.cs
+++ b/UserInterface/Program.cs
@@ -9,7 +9,7 @@
             ConsoleRenderer renderer = new ConsoleRenderer();
             SaveManager saver = new SaveManager();
             GameManager gameManager = new GameManager(renderer, saver);
-            GameMenuManager menuManager = new GameMenuManager(gameManager, renderer);
+            GameMenuManager menuManager = new GameMenuManager(gameManager, renderer, saver);
 
             menuManager.ShowMainMenu();
         }

--- a/UserInterface/Program.cs
+++ b/UserInterface/Program.cs
@@ -9,7 +9,7 @@
             ConsoleRenderer renderer = new ConsoleRenderer();
             SaveManager saver = new SaveManager();
             GameManager gameManager = new GameManager(renderer, saver);
-            GameMenuManager menuManager = new GameMenuManager(gameManager);
+            GameMenuManager menuManager = new GameMenuManager(gameManager, renderer);
 
             menuManager.ShowMainMenu();
         }


### PR DESCRIPTION
# Completed Iteration 3 requirements
## Added 1000 parallel game test functionality, displaying all related statistics in a dashboard-style view while 1000 games run at the same time.
User can navigate through pages of games running in parallel at the same time using N and P for next and previous pages respectively to view the Game of Life instances.
![image](https://github.com/user-attachments/assets/e2cdfe60-3d15-4b51-a620-b4c833c056eb)
![image](https://github.com/user-attachments/assets/64a658a6-f9c1-4f0d-9d22-4621096d23a7)

---

User can Save all 1000 games at the same time by pressing S and then Load the latest 1000 parallel game save by pressing L at any point during runtime.
Parallel save games can also be loaded later through the load game option in the main menu so the user may continue the 1000 parallel game execution at any time. Parallel save games are automatically named following the naming convention of "parallel_save_{CURRENT TIME AND DATE}.json"
![image](https://github.com/user-attachments/assets/4861b943-e952-4a02-b07d-5819043c3b89)

---

Player can view 8 games at once in a Multi-game display by pressing M at any point during runtime and navigate through pages of the parallel Game of Life instances. (zooming out the console a little may be required for this functionality, couldn't find how to fix that yet)
![image](https://github.com/user-attachments/assets/06ca140a-0fc0-4c64-853a-1a421ec8962c)